### PR TITLE
chore: add convenience target to build singularity env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+prepare_apptainer_env:
+	cd envs && ./build_singularity.sh

--- a/envs/build_singularity.sh
+++ b/envs/build_singularity.sh
@@ -1,9 +1,5 @@
-#!/bin/bash
-
-sudo singularity build sklearn.sif sklearn_singularity.def
-
-sudo singularity build clustbench.sif clustbench_singularity.def
-
-sudo singularity build r.sif r_singularity.def
-
-sudo singularity build fcps.sif fcps_singularity.def
+#!/bin/sh
+singularity build sklearn.sif sklearn_singularity.def
+singularity build clustbench.sif clustbench_singularity.def
+singularity build r.sif r_singularity.def
+singularity build fcps.sif fcps_singularity.def


### PR DESCRIPTION
- make script executable
- use /bin/sh instead of /bin/bash
- add top-level Makefile to prepare env
- remove use of sudo (?); if needed the script execution can be granted root access by the caller