### PR TITLE
Add a 'benchmark' trigger for BC2

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,22 @@
+name: benchmark_bc2_trigger
+on:
+  push:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: "30 1 * * *" # at 1.30am
+    
+jobs:
+  run_benchmark_main:
+    name: Run on conda
+    runs-on: ubuntu-latest
+    # runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use action 
+        uses: omnibenchmark/run_omnibenchmark@main
+        with:
+          yaml: Clustering_conda.yml
+          backend: conda
+          omnibenchmark_branch: 'dev'


### PR DESCRIPTION
To be browsed at https://github.com/omnibenchmark/clustering_example/actions/workflows/benchmark.yml

Mind this runs the whole/large benchmark, and on 'omnibenchmark dev', so perhaps worth reducing its scope by adding a `tiny_custering_conda.yml`